### PR TITLE
Disables EmptyBlock and Spread

### DIFF
--- a/kotlin/src/main/resources/detekt.yml
+++ b/kotlin/src/main/resources/detekt.yml
@@ -140,7 +140,7 @@ empty-blocks:
   EmptyForBlock:
     active: true
   EmptyFunctionBlock:
-    active: true
+    active: false
     ignoreOverridden: false
   EmptyIfBlock:
     active: true
@@ -414,8 +414,7 @@ performance:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
   SpreadOperator:
-    active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
+    active: false
   UnnecessaryTemporaryInstantiation:
     active: true
 


### PR DESCRIPTION
Reasonning : 

*EmptyFunctionBlock*
Ca arrive mettons dans une implémentation NoOp. C'est quand meme gossant,  pis y'a pas de cas où j'vais laissé un body vide sans le vouloir, pis si oui ça passera pas le code review!

*Spread*
C'est juste un concern de perf, mais c'pas that bad. Selon moi si tu sais que le spread existe tu sais qu'il faut faire attention. Sinon, ca simplifie du code pareil! Genre ca c'est la facon de faire pour picocli : 

```
fun main(args: Array<String>) {
    Security.insertProviderAt(BouncyCastleProvider(), 0)
    PicocliRunner.run(GatewayTdCommand::class.java, *args)
}
```