### PR TITLE
Update to kotlin 1.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-java adopt-openjdk-11.0.7+10
+java adoptopenjdk-11.0.8+10
 nodejs 12.16.3
 yarn 1.22.4

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,16 +1,17 @@
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import org.jmailen.gradle.kotlinter.KotlinterExtension
 
 group = "com.equisoft.standards"
-version = "0.2.0"
+version = "0.4.0"
 
 plugins {
-    kotlin("jvm") version "1.3.71"
+    kotlin("jvm") version "1.4.10"
 
     id("java-gradle-plugin")
 
     id("com.gradle.plugin-publish") version "0.11.0"
-    id("io.gitlab.arturbosch.detekt") version "1.8.0"
-    id("org.jmailen.kotlinter") version "2.3.2"
+    id("io.gitlab.arturbosch.detekt") version "1.13.1"
+    id("org.jmailen.kotlinter") version "3.2.0"
 }
 
 repositories {
@@ -26,8 +27,12 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
-    implementation("org.jmailen.gradle:kotlinter-gradle:2.3.2")
-    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.8.0")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10")
+    implementation("org.jmailen.gradle:kotlinter-gradle:3.2.0")
+    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.13.1")
+
+    // Custom rule dependency because of https://github.com/pinterest/ktlint/issues/764
+    implementation("com.pinterest.ktlint:ktlint-core:0.39.0")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
@@ -79,6 +84,10 @@ configure<DetektExtension> {
         file("src/test/kotlin"),
         functionalTestSourceSet.allSource.files
     )
+}
+
+configure<KotlinterExtension> {
+    disabledRules = arrayOf("indent") // https://github.com/pinterest/ktlint/issues/764
 }
 
 tasks {

--- a/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kotlin/src/functionalTest/kotlin/com/equisoft/standards/kotlin/KotlinStandardsPluginFunctionalTest.kt
+++ b/kotlin/src/functionalTest/kotlin/com/equisoft/standards/kotlin/KotlinStandardsPluginFunctionalTest.kt
@@ -20,16 +20,7 @@ class KotlinStandardsPluginFunctionalTest {
     @BeforeTest
     fun setUp() {
         projectDir = Files.createTempDirectory("kotlin-standards").toFile()
-        projectDir.resolve("settings.gradle.kts").writeText("")
-        projectDir.resolve("build.gradle.kts").writeText("""
-            plugins {
-                kotlin("jvm") version "1.3.71"
-                id("com.equisoft.standards.kotlin")
-            }
-            repositories {
-                jcenter()
-            }
-        """.trimIndent())
+        createGradleFiles()
 
         sourcesDir = createProjectSubDirectory("src/main/kotlin")
         testsDir = createProjectSubDirectory("src/test/kotlin")
@@ -44,6 +35,19 @@ class KotlinStandardsPluginFunctionalTest {
             .withProjectDir(projectDir)
     }
 
+    private fun createGradleFiles() {
+        projectDir.resolve("settings.gradle.kts").writeText("")
+        projectDir.resolve("build.gradle.kts").writeText("""
+                plugins {
+                    kotlin("jvm") version "1.4.10"
+                    id("com.equisoft.standards.kotlin")
+                }
+                repositories {
+                    jcenter()
+                }
+            """.trimIndent())
+    }
+
     @AfterTest
     fun tearDown() {
         projectDir.deleteRecursively()
@@ -53,14 +57,14 @@ class KotlinStandardsPluginFunctionalTest {
     inner class Kotlinter {
         @Test
         fun `check should run kotlinter`() {
-            val result = runner.withArguments("check").build()
+            val result = runner.withArguments("check", "-xdetekt").build()
 
             assertKotlinterSuccess(result)
         }
 
         @Test
         fun `checkStatic should run kotlinter`() {
-            val result = runner.withArguments("checkStatic").build()
+            val result = runner.withArguments("checkStatic", "-xdetekt").build()
 
             assertKotlinterSuccess(result)
         }
@@ -77,7 +81,7 @@ class KotlinStandardsPluginFunctionalTest {
             class IgnoreImportOrder
         """.trimIndent())
 
-            val result = runner.withArguments("checkStatic").build()
+            val result = runner.withArguments("checkStatic", "-xdetekt").build()
 
             assertKotlinterSuccess(result)
         }
@@ -93,14 +97,14 @@ class KotlinStandardsPluginFunctionalTest {
     inner class Detekt {
         @Test
         fun `check should run detekt`() {
-            val result = runner.withArguments("check").build()
+            val result = runner.withArguments("check", "-xlintKotlin").build()
 
             assertDetektSuccess(result)
         }
 
         @Test
         fun `checkStatic should run detekt`() {
-            val result = runner.withArguments("checkStatic").build()
+            val result = runner.withArguments("checkStatic", "-xlintKotlin").build()
 
             assertDetektSuccess(result)
         }

--- a/kotlin/src/main/kotlin/com/equisoft/standards/kotlin/ktlint/CustomRuleSetProvider.kt
+++ b/kotlin/src/main/kotlin/com/equisoft/standards/kotlin/ktlint/CustomRuleSetProvider.kt
@@ -1,0 +1,8 @@
+package com.equisoft.standards.kotlin.ktlint
+
+import com.pinterest.ktlint.core.RuleSet
+import com.pinterest.ktlint.core.RuleSetProvider
+
+class CustomRuleSetProvider : RuleSetProvider {
+    override fun get() = RuleSet("equisoft", IndentationRule())
+}

--- a/kotlin/src/main/kotlin/com/equisoft/standards/kotlin/ktlint/IndentationRule.kt
+++ b/kotlin/src/main/kotlin/com/equisoft/standards/kotlin/ktlint/IndentationRule.kt
@@ -1,0 +1,89 @@
+@file:SuppressWarnings("all")
+/* ktlint-disable */
+
+package com.equisoft.standards.kotlin.ktlint
+
+import com.pinterest.ktlint.core.KtLint
+import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.ast.ElementType.CONSTRUCTOR_DELEGATION_CALL
+import com.pinterest.ktlint.core.ast.ElementType.SUPER_TYPE_LIST
+import com.pinterest.ktlint.core.ast.ElementType.TYPE_REFERENCE
+import com.pinterest.ktlint.core.ast.isPartOf
+import com.pinterest.ktlint.core.ast.isRoot
+import com.pinterest.ktlint.core.ast.nextLeaf
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiComment
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.psi.KtParameterList
+import org.jetbrains.kotlin.psi.KtTypeConstraintList
+
+/**
+ * This is the rule from version 0.36.0 which doesn't trigger this issue:
+ * https://github.com/pinterest/ktlint/issues/764
+ */
+class IndentationRule : Rule("indent") {
+    private var indentSize = -1
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (node.isRoot()) {
+            val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
+            indentSize = editorConfig.indentSize
+            return
+        }
+        if (indentSize <= 1) {
+            return
+        }
+        if (node is PsiWhiteSpace && !node.isPartOf(PsiComment::class)) {
+            val lines = node.getText().split("\n")
+            if (lines.size > 1 && !node.isPartOf(KtTypeConstraintList::class)) {
+                var offset = node.startOffset + lines.first().length + 1
+                val previousIndentSize = node.previousIndentSize()
+                lines.tail().forEach { indent ->
+                    if (indent.isNotEmpty() && (indent.length - previousIndentSize) % indentSize != 0) {
+                        if (!node.isPartOf(KtParameterList::class)) { // parameter list wrapping enforced by ParameterListWrappingRule
+                            emit(
+                                offset,
+                                "Unexpected indentation (${indent.length}) (it should be ${previousIndentSize + indentSize})",
+                                false
+                            )
+                        }
+                    }
+                    offset += indent.length + 1
+                }
+            }
+            if (node.textContains('\t')) {
+                val text = node.getText()
+                emit(node.startOffset + text.indexOf('\t'), "Unexpected Tab character(s)", true)
+                if (autoCorrect) {
+                    (node as LeafPsiElement).rawReplaceWithText(text.replace("\t", " ".repeat(indentSize)))
+                }
+            }
+        }
+    }
+
+    private fun ASTNode.previousIndentSize(): Int {
+        var node: ASTNode? = this.treeParent
+        while (node != null) {
+            val nextNode = node.treeNext?.elementType
+            if (node is PsiWhiteSpace &&
+                nextNode != TYPE_REFERENCE &&
+                nextNode != SUPER_TYPE_LIST &&
+                nextNode != CONSTRUCTOR_DELEGATION_CALL &&
+                node.textContains('\n') &&
+                node.nextLeaf()?.isPartOf(PsiComment::class) != true
+            ) {
+                val text = node.getText()
+                return text.length - text.lastIndexOf('\n') - 1
+            }
+            node = node.treePrev ?: node.treeParent
+        }
+        return 0
+    }
+}
+
+internal fun <T> List<T>.tail() = this.subList(1, this.size)

--- a/kotlin/src/main/resources/META-INF/services/com.pinterest.ktlint.core.RuleSetProvider
+++ b/kotlin/src/main/resources/META-INF/services/com.pinterest.ktlint.core.RuleSetProvider
@@ -1,0 +1,1 @@
+com.equisoft.standards.kotlin.ktlint.CustomRuleSetProvider

--- a/kotlin/src/main/resources/detekt.yml
+++ b/kotlin/src/main/resources/detekt.yml
@@ -235,6 +235,7 @@ formatting:
   ImportOrdering:
     active: true
     autoCorrect: true
+    layout: 'idea'
   Indentation:
     active: false
     autoCorrect: true
@@ -303,6 +304,9 @@ formatting:
   SpacingAroundDot:
     active: true
     autoCorrect: true
+  SpacingAroundDoubleColon:
+    active: true
+    autoCorrect: true
   SpacingAroundKeyword:
     active: true
     autoCorrect: true
@@ -313,6 +317,12 @@ formatting:
     active: true
     autoCorrect: true
   SpacingAroundRangeOperator:
+    active: true
+    autoCorrect: true
+  SpacingBetweenDeclarationsWithAnnotations:
+    active: true
+    autoCorrect: true
+  SpacingBetweenDeclarationsWithComments:
     active: true
     autoCorrect: true
   StringTemplate:
@@ -361,7 +371,7 @@ naming:
     excludeClassPattern: '$^'
     ignoreOverridden: true
   InvalidPackageDeclaration:
-    active: true
+    active: false
     rootPackage: ''
   MatchingDeclarationName:
     active: true
@@ -369,6 +379,9 @@ naming:
   MemberNameEqualsClassName:
     active: true
     ignoreOverridden: true
+  NonBooleanPropertyPrefixedWithIs:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
   ObjectPropertyNaming:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
@@ -427,6 +440,10 @@ potential-bugs:
     active: true
   HasPlatformType:
     active: false
+  IgnoredReturnValue:
+    active: false
+    restrictToAnnotatedMethods: true
+    returnValueAnnotations: ['*.CheckReturnValue', '*.CheckResult']
   ImplicitDefaultLocale:
     active: false
   InvalidRange:
@@ -435,6 +452,9 @@ potential-bugs:
     active: true
   IteratorNotThrowingNoSuchElementException:
     active: true
+  ImplicitUnitReturnType:
+    active: false
+    allowExplicitReturnType: true
   LateinitUsage:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt']
@@ -443,6 +463,8 @@ potential-bugs:
   MapGetWithNotNullAssertionOperator:
     active: false
   MissingWhenCase:
+    active: true
+  NullableToStringCall:
     active: true
   RedundantElseInWhen:
     active: true
@@ -508,6 +530,8 @@ style:
     excludeAnnotatedFunction: ['dagger.Provides']
   LibraryCodeMustSpecifyReturnType:
     active: true
+  LibraryEntitiesShouldNotBePublic:
+    active: true
   LoopWithTooManyJumpStatements:
     active: true
     maxJumpCount: 1
@@ -526,6 +550,8 @@ style:
     ignoreRanges: false
   MandatoryBracesIfStatements:
     active: false
+  MandatoryBracesLoops:
+    active: true
   MaxLineLength:
     active: true
     maxLineLength: 120
@@ -601,15 +627,21 @@ style:
     allowedNames: '(_|ignored|expected|serialVersionUID)'
   UseArrayLiteralsInAnnotations:
     active: true
+  UseCheckNotNull:
+    active: true
   UseCheckOrError:
     active: false
   UseDataClass:
     active: false
     excludeAnnotatedClasses: []
     allowVars: false
+  UseEmptyCounterpart:
+    active: true
   UseIfInsteadOfWhen:
     active: false
   UseRequire:
+    active: true
+  UseRequireNotNull:
     active: true
   UselessCallOnNotNull:
     active: true


### PR DESCRIPTION
J'ai pas eu le choix de ramener la rule de 0.36.0 pour qu'on puisse updater nos projets à 1.4 et garder le plugin en attendant qu'ils fixent l'issue. Sinon ça faisait trop de changements d'indent à faire, et certains sont assez douteux (voir https://github.com/pinterest/ktlint/issues/764)