### PR TITLE
Disable react/require-default-props

### DIFF
--- a/javascript/packages/eslint-config-react/index.js
+++ b/javascript/packages/eslint-config-react/index.js
@@ -16,7 +16,6 @@ module.exports = {
     rules: {
         'import/no-extraneous-dependencies': 'off',
         'no-underscore-dangle': ['error', { 'allowAfterThis': true }],
-        'react/require-default-props': 'off',
         'react/destructuring-assignment': 'off',
         'react/jsx-indent': ['error', 4],
         'react/jsx-indent-props': ['error', 4],
@@ -28,6 +27,7 @@ module.exports = {
         },
         ],
         'react/prop-types': 'off',
+        'react/require-default-props': 'off',
     },
     overrides: [
         { files: ['*.js', '*.jsx'] },

--- a/javascript/packages/eslint-config-react/index.js
+++ b/javascript/packages/eslint-config-react/index.js
@@ -16,6 +16,7 @@ module.exports = {
     rules: {
         'import/no-extraneous-dependencies': 'off',
         'no-underscore-dangle': ['error', { 'allowAfterThis': true }],
+        'react/require-default-props': 'off',
         'react/destructuring-assignment': 'off',
         'react/jsx-indent': ['error', 4],
         'react/jsx-indent-props': ['error', 4],


### PR DESCRIPTION
Considérant https://github.com/facebook/react/pull/16210, et qu'on utilise presque exclusivement des functional components. la rule est plus dans les jambes qu'autre chose