### PR TITLE
Disable react/jsx-props-no-spreading for tests

### DIFF
--- a/javascript/packages/eslint-config-react/index.js
+++ b/javascript/packages/eslint-config-react/index.js
@@ -30,5 +30,11 @@ module.exports = {
     },
     overrides: [
         { files: ['*.js', '*.jsx'] },
+        {
+            files: ['**/*.@(test|spec).jsx'],
+            rules: {
+                'react/jsx-props-no-spreading': 'off',
+            },
+        }
     ],
 };

--- a/javascript/packages/eslint-config-typescript-react/index.js
+++ b/javascript/packages/eslint-config-typescript-react/index.js
@@ -7,4 +7,12 @@ module.exports = {
     rules: {
         'react/jsx-filename-extension': ['error', { extensions: ['.jsx', '.tsx'] }],
     },
+    overrides: [
+        {
+            files: ['**/*.@(test|spec).tsx'],
+            rules: {
+                'react/jsx-props-no-spreading': 'off',
+            },
+        }
+    ],
 };


### PR DESCRIPTION
Je pense que c'est assez fréquent que pour les tests on spread certaines props communes à tous les tests.