### PR TITLE
Change react/default-props-match-prop-types to allowRequiredDefaults

### DIFF
--- a/javascript/packages/eslint-config-react/index.js
+++ b/javascript/packages/eslint-config-react/index.js
@@ -16,6 +16,7 @@ module.exports = {
     rules: {
         'import/no-extraneous-dependencies': 'off',
         'no-underscore-dangle': ['error', { 'allowAfterThis': true }],
+        'react/default-props-match-prop-types': ['error', { allowRequiredDefaults: true }],
         'react/destructuring-assignment': 'off',
         'react/jsx-indent': ['error', 4],
         'react/jsx-indent-props': ['error', 4],


### PR DESCRIPTION
Désolé pour le nombre de PRs, je voulais pas nécessairement tout bundler les propositions ensemble :P

Voir https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/default-props-match-prop-types.md#allowrequireddefaults