### PR TITLE
feat(eslint): allow explicit console log levels

### DIFF
--- a/javascript/packages/eslint-config/index.js
+++ b/javascript/packages/eslint-config/index.js
@@ -28,6 +28,7 @@ module.exports = {
         'no-mixed-operators': ['error', { 'allowSamePrecedence': true }],
         'no-plusplus': ['error', { 'allowForLoopAfterthoughts': true }],
         'no-cond-assign': ['error', 'except-parens'],
+        'no-console': ['error', { allow: ['info', 'warn', 'error', 'trace'] }],
         'no-return-assign': ['error', 'except-parens'],
         'prefer-destructuring': 'off',
     },


### PR DESCRIPTION
On semble mettre l'override pas mal partout. Aussi c'est assez pratique pour du feedback juste en dev tant que c'est pas abusé.