### PR TITLE
fix(eslint-typescript) : Replace no-shadow with @typescript version

### DIFF
--- a/javascript/packages/eslint-config-typescript/index.js
+++ b/javascript/packages/eslint-config-typescript/index.js
@@ -42,6 +42,9 @@ module.exports = {
                 'ts-ignore': 'allow-with-description',
             },
         ],
+        
+        "no-shadow": "off",
+        "@typescript-eslint/no-shadow": ["error"]
 
         // Useless in TypeScript
         'consistent-return': 'off',


### PR DESCRIPTION
Ça me donne l'erreur 
`1:13  error  'IvariLocale' is already declared in the upper scope  no-shadow`
sinon pour
`export enum IvariLocale { Fr = 'fr', En = 'en' }`