### PR TITLE
chore(eslint) : Update lines-between-class-members

### DIFF
--- a/javascript/packages/eslint-config/index.js
+++ b/javascript/packages/eslint-config/index.js
@@ -16,6 +16,9 @@ module.exports = {
         'import/prefer-default-export': 'off',
         'import/no-default-export': ['error'],
         'indent': ['error', 4, { 'SwitchCase': 1 }],
+        'lines-between-class-members': [
+            'error', 'always', { exceptAfterSingleLine true }
+        ],
         'max-len': [
             'error',
             {

--- a/javascript/packages/eslint-config/index.js
+++ b/javascript/packages/eslint-config/index.js
@@ -17,7 +17,7 @@ module.exports = {
         'import/no-default-export': ['error'],
         'indent': ['error', 4, { 'SwitchCase': 1 }],
         'lines-between-class-members': [
-            'error', 'always', { exceptAfterSingleLine true }
+            'error', 'always', { 'exceptAfterSingleLine': true },
         ],
         'max-len': [
             'error',


### PR DESCRIPTION
C'est une proposition, mais sinon ça oblige des newlines entre les fields
```
class X {
    private readonly A = 1;

    private readonly B = 2;

    private readonly C = 3;
}
```