### PR TITLE
feat(kotlin): disable UnnecessaryLet

### DIFF
--- a/gradle/kotlin/build.gradle.kts
+++ b/gradle/kotlin/build.gradle.kts
@@ -1,6 +1,6 @@
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 
-version = "1.0.1-SNAPSHOT"
+version = "1.0.2-SNAPSHOT"
 
 val functionalTestImplementation = configurations
     .create("functionalTestImplementation")

--- a/gradle/kotlin/src/main/resources/detekt.yml
+++ b/gradle/kotlin/src/main/resources/detekt.yml
@@ -134,8 +134,6 @@ style:
   UnderscoresInNumericLiterals:
     active: true
     acceptableLength: 5
-  UnnecessaryLet:
-    active: true
   UseArrayLiteralsInAnnotations:
     active: true
   UseCheckNotNull:


### PR DESCRIPTION
This rule detects places where let actually improves readability.

I guess it was disabled by default for a reason.