### PR TITLE
fix(gitleaks): fix CI var check crash on mac caused by old bash version installed by default on macos

### DIFF
--- a/bin/gitleaks.bash
+++ b/bin/gitleaks.bash
@@ -31,7 +31,7 @@ else
 fi
 OPTIONS+=("--config=$CONTAINER_PATH/$BUILD_OUTPUT/gitleaks.toml")
 
-if [[ -v CI ]]; then
+if [[ -n "${CI:-}" ]]; then
     OPTIONS+=("--redact")
 
     if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then


### PR DESCRIPTION
MacOs a une très vieille version de Bash installé par défaut, et donc, ça cause un crash sur l'opération `if [[ -v CI ]]`.
L'erreur soulevé par la console est:
```
bash: line 34: conditional binary operator expected
make[1]: *** [check_secrets] Error 2
make: *** [check] Error 2
```