### PR TITLE
feat(gradle/micronaut): update transitive plugins

### DIFF
--- a/gradle/build.gradle.kts
+++ b/gradle/build.gradle.kts
@@ -143,6 +143,6 @@ tasks {
 
     wrapper {
         distributionType = Wrapper.DistributionType.ALL
-        gradleVersion = "7.4.2"
+        gradleVersion = "7.5"
     }
 }

--- a/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/micronaut/build.gradle.kts
+++ b/gradle/micronaut/build.gradle.kts
@@ -6,13 +6,13 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion")
 
-    val micronautPluginVersion = "3.3.2"
+    val micronautPluginVersion = "3.5.0"
     implementation("io.micronaut.gradle:micronaut-docker-plugin:$micronautPluginVersion")
     implementation("io.micronaut.gradle:micronaut-graalvm-plugin:$micronautPluginVersion")
     implementation("io.micronaut.gradle:micronaut-gradle-plugin:$micronautPluginVersion")
     implementation("io.micronaut.gradle:micronaut-minimal-plugin:$micronautPluginVersion")
-    implementation("com.bmuschko:gradle-docker-plugin:7.3.0")
-    implementation("org.graalvm.buildtools:native-gradle-plugin:0.9.11")
+    implementation("com.bmuschko:gradle-docker-plugin:7.4.0")
+    implementation("org.graalvm.buildtools:native-gradle-plugin:0.9.13")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 

--- a/gradle/micronaut/build.gradle.kts
+++ b/gradle/micronaut/build.gradle.kts
@@ -1,4 +1,4 @@
-version = "0.4.0-SNAPSHOT"
+version = "0.5.0-SNAPSHOT"
 
 dependencies {
     val kotlinVersion = "1.6.21"


### PR DESCRIPTION
micronaut-gradle-plugin:3.4.0 added support for the LAMBDA_CUSTOM runtime which I need to use.