### PR TITLE
chore(renovate): group kotlin, micronaut, equisoft

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -59,8 +59,26 @@
       },
       {
         "matchUpdateTypes": ["minor"],
+        "excludePackagePrefixes": [
+          "org.jetbrains.kotlin",
+          "io.micronaut",
+          "com.equisoft",
+          "io.equisoft"
+        ],
         "groupName": "Gradle minors",
       },
+      {
+        "matchPackagePrefixes": ["org.jetbrains.kotlin"],
+        "groupName": "Kotlin",
+      },
+      {
+        "matchPackagePrefixes": ["io.micronaut"],
+        "groupName": "Micronaut",
+      },
+      {
+        "matchPackagePrefixes": ["com.equisoft", "io.equisoft"],
+        "groupName": "Equisoft",
+      },,
       {
         "matchUpdateTypes": ["patch"],
         "groupName": "Gradle patches",


### PR DESCRIPTION
Group kotlin, micronaut and equisoft minors & majors together. They will not be grouped with the larger "Gradle minors" group. Patches are not affected by this change.

This should help limit breaking changes in the "Gradle minors" group and help us merge it more often.