### PR TITLE
feat(renovate): enable automerge

### DIFF
--- a/.github/workflows/validate-renovate.yaml
+++ b/.github/workflows/validate-renovate.yaml
@@ -1,0 +1,28 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  validate-renovate:
+    runs-on: ubuntu-latest
+    env:
+      FILES: renovate-config.json renovate-base.json
+      SCHEMA_URL: https://docs.renovatebot.com/renovate-schema.json
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: pip
+          cache-dependency-path: .github/workflows/validate-renovate.yaml
+      - run: pip install check-jsonschema
+      - run: |
+          curl -L -o renovate.schema "$SCHEMA_URL"
+          jq '. *= {"additionalProperties": false, "properties": {"$schema": {"type": "string", "format": "uri", "default": ""}}}' \
+            renovate.schema > /tmp/renovate.schema && mv /tmp/renovate.schema renovate.schema
+      - run: |
+          check-jsonschema --schemafile renovate.schema --output-format text $FILES

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -4,7 +4,8 @@
     "config:base"
   ],
   "labels": ["dependency-update"],
-  "automerge": false,
+  "automerge": true,
+  "automergeType": "pr",
   "platformAutomerge": true,
   "packageRules": [
     {


### PR DESCRIPTION
Every time we merge a renovate PR, we must both approve it then click the merge button. Since we require approval on (almost) all PRs in branch protections, automerge will really happen only when we approve the PR.

https://docs.renovatebot.com/configuration-options/#platformautomerge