### PR TITLE
fix(javascript/eslint-*): include eslint script in all packages

### DIFF
--- a/javascript/packages/eslint-config-react/eslint.js
+++ b/javascript/packages/eslint-config-react/eslint.js
@@ -1,0 +1,1 @@
+module.exports = require('@equisoft/eslint-config/eslint');

--- a/javascript/packages/eslint-config-react/package.json
+++ b/javascript/packages/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equisoft/eslint-config-react",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Equisoft's React ESLint config, based on eslint-config-airbnb",
   "main": "index.js",
   "license": "MIT",
@@ -24,6 +24,9 @@
     "equisoft",
     "react"
   ],
+  "bin": {
+    "eslint": "eslint.js"
+  },
   "dependencies": {
     "@equisoft/eslint-config": "workspace:*",
     "eslint-config-airbnb": "^19.0.4"

--- a/javascript/packages/eslint-config-typescript-react/eslint.js
+++ b/javascript/packages/eslint-config-typescript-react/eslint.js
@@ -1,0 +1,1 @@
+module.exports = require('@equisoft/eslint-config/eslint');

--- a/javascript/packages/eslint-config-typescript-react/package.json
+++ b/javascript/packages/eslint-config-typescript-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equisoft/eslint-config-typescript-react",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Equisoft's TypeScript ESLint configuration for React. Based on eslint-config-react",
   "license": "MIT",
   "main": "index.js",
@@ -25,6 +25,9 @@
     "react",
     "typescript"
   ],
+  "bin": {
+    "eslint": "eslint.js"
+  },
   "dependencies": {
     "@equisoft/eslint-config-react": "workspace:*",
     "@equisoft/eslint-config-typescript": "workspace:*"

--- a/javascript/packages/eslint-config-typescript/eslint.js
+++ b/javascript/packages/eslint-config-typescript/eslint.js
@@ -1,0 +1,1 @@
+module.exports = require('@equisoft/eslint-config/eslint');

--- a/javascript/packages/eslint-config-typescript/package.json
+++ b/javascript/packages/eslint-config-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equisoft/eslint-config-typescript",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Equisoft's TypeScript ESLint configuration. Based on eslint-config",
   "license": "MIT",
   "main": "index.js",
@@ -24,6 +24,9 @@
     "equisoft",
     "typescript"
   ],
+  "bin": {
+    "eslint": "eslint.js"
+  },
   "dependencies": {
     "@equisoft/eslint-config": "workspace:*"
   },

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -176,6 +176,8 @@ __metadata:
     eslint-plugin-react: ^7
     eslint-plugin-react-hooks: ^4
     yargs: ^17
+  bin:
+    eslint: eslint.js
   languageName: unknown
   linkType: soft
 
@@ -206,6 +208,8 @@ __metadata:
     eslint-plugin-react: ^7
     eslint-plugin-react-hooks: ^4
     yargs: ^17
+  bin:
+    eslint: eslint.js
   languageName: unknown
   linkType: soft
 
@@ -229,6 +233,8 @@ __metadata:
     eslint-import-resolver-typescript: ^2
     eslint-plugin-import: ^2
     yargs: ^17
+  bin:
+    eslint: eslint.js
   languageName: unknown
   linkType: soft
 
@@ -1403,7 +1409,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.12":
+"fast-glob@npm:^3.2.12, fast-glob@npm:^3.2.9":
   version: 3.2.12
   resolution: "fast-glob@npm:3.2.12"
   dependencies:
@@ -1413,19 +1419,6 @@ __metadata:
     merge2: ^1.3.0
     micromatch: ^4.0.4
   checksum: 0b1990f6ce831c7e28c4d505edcdaad8e27e88ab9fa65eedadb730438cfc7cde4910d6c975d6b7b8dc8a73da4773702ebcfcd6e3518e73938bb1383badfe01c2
-  languageName: node
-  linkType: hard
-
-"fast-glob@npm:^3.2.9":
-  version: 3.2.11
-  resolution: "fast-glob@npm:3.2.11"
-  dependencies:
-    "@nodelib/fs.stat": ^2.0.2
-    "@nodelib/fs.walk": ^1.2.3
-    glob-parent: ^5.1.2
-    merge2: ^1.3.0
-    micromatch: ^4.0.4
-  checksum: f473105324a7780a20c06de842e15ddbb41d3cb7e71d1e4fe6e8373204f22245d54f5ab9e2061e6a1c613047345954d29b022e0e76f5c28b1df9858179a0e6d7
   languageName: node
   linkType: hard
 
@@ -2596,16 +2589,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-scss@npm:^4.0.2":
-  version: 4.0.4
-  resolution: "postcss-scss@npm:4.0.4"
-  peerDependencies:
-    postcss: ^8.3.3
-  checksum: b4f240dd5eeb0c21738b673d9caf9a06b9a6db665a5b1c815ee4ca10c4c74a67c54f11cd5a4970dea98475cbb9e6d846e05dd3e48924189c2ecbf1f50cd44aa4
-  languageName: node
-  linkType: hard
-
-"postcss-scss@npm:~4.0.5":
+"postcss-scss@npm:^4.0.2, postcss-scss@npm:~4.0.5":
   version: 4.0.5
   resolution: "postcss-scss@npm:4.0.5"
   peerDependencies:
@@ -2650,18 +2634,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.3.11":
-  version: 8.4.14
-  resolution: "postcss@npm:8.4.14"
-  dependencies:
-    nanoid: ^3.3.4
-    picocolors: ^1.0.0
-    source-map-js: ^1.0.2
-  checksum: fe58766ff32e4becf65a7d57678995cfd239df6deed2fe0557f038b47c94e4132e7e5f68b5aa820c13adfec32e523b693efaeb65798efb995ce49ccd83953816
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.4.17":
+"postcss@npm:^8.3.11, postcss@npm:^8.4.17":
   version: 8.4.18
   resolution: "postcss@npm:8.4.18"
   dependencies:


### PR DESCRIPTION
Ça va éviter de dépendre directement du package `eslint-config` directement même si c'est une dépendance transitive.