### PR TITLE
renovate: Disable automerge for Helm

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -43,6 +43,11 @@
     {
       "matchUpdateTypes": ["patch"],
       "addLabels": ["patch"]
+    },
+    {
+      "matchDatasources": ["helm"],
+      "automerge": false,
+      "addLabels": ["helm"]
     }
   ],
   "schedule": [


### PR DESCRIPTION
Renovate met à jour staging automatiquement dans richard (parce que required pas d'approval). Je n'aime pas trop ce comportement, donc je désactive le automerge pour les helm.

cf: https://github.com/kronostechnologies/richard/pull/971