### PR TITLE
renovate: support comment based dependency detection

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -182,5 +182,16 @@
         "matchUpdateTypes": ["major"]
       }
     ]
-  }
+  },
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "(^|/|\\.)([Dd]ocker|[Cc]ontainer)file$",
+        "(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$"
+      ],
+      "matchStrings": [
+        "#\\s?renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s(ARG|ENV) .*?_VERSION=(?<currentValue>.*)\\s"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This will detect custom dependencies in Dockerfiles based on a special syntax. A comment that begins with `# renovate: ` and and arg/env that ends with `_VERSION`:

```dockerfile
# renovate: datasource=github-releases depName=asdf-vm/asdf
ARG ASDF_VERSION=v0.11.3
```

Tested in webapp-boilerplate