### PR TITLE
chore: add versioning template to Dockerfile's regexManager

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -190,8 +190,9 @@
         "(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$"
       ],
       "matchStrings": [
-        "#\\s?renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s(ARG|ENV) .*?_VERSION=(?<currentValue>.*)\\s"
-      ]
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s(ARG|ENV) .*?_VERSION=(?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }
   ]
 }


### PR DESCRIPTION
Ça va être nécessaire pour configurer les versions qui viennent des repos alpine: https://docs.renovatebot.com/modules/datasource/repology/