### PR TITLE
QCTECH-554 Update kotlin and detekt + remove kotlinter

### DIFF
--- a/gradle/build.gradle.kts
+++ b/gradle/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 
     id("com.github.ben-manes.versions") version "0.42.0"
     id("org.cyclonedx.bom") version "1.5.0"
-    id("org.jmailen.kotlinter") version "3.10.0" apply false
     id("io.gitlab.arturbosch.detekt") version "1.23.0" apply false
 }
 
@@ -20,7 +19,6 @@ subprojects {
         plugin("org.gradle.java-gradle-plugin")
         plugin("org.gradle.kotlin.kotlin-dsl")
         plugin("org.gradle.maven-publish")
-        plugin("org.jmailen.kotlinter")
         plugin("io.gitlab.arturbosch.detekt")
     }
 
@@ -61,12 +59,6 @@ subprojects {
         config = files("$rootDir/kotlin/src/main/resources/detekt.yml")
     }
 
-
-    configure<org.jmailen.gradle.kotlinter.KotlinterExtension> {
-        reporters = arrayOf("checkstyle", "plain", "sarif")
-        disabledRules = arrayOf("import-ordering")
-    }
-
     configure<PublishingExtension> {
         repositories {
             maven {
@@ -103,7 +95,7 @@ subprojects {
 
         register("checkStatic") {
             group = "verification"
-            dependsOn("lintKotlin", "detekt")
+            dependsOn("detekt")
         }
 
         named("build") {

--- a/gradle/build.gradle.kts
+++ b/gradle/build.gradle.kts
@@ -40,7 +40,6 @@ subprojects {
 
     dependencies {
         CONFIGURATION_DETEKT_PLUGINS("io.gitlab.arturbosch.detekt:detekt-formatting:$detektVersion")
-        CONFIGURATION_DETEKT_PLUGINS("io.gitlab.arturbosch.detekt:detekt-rules-libraries:$detektVersion")
     }
 
     configure<JavaPluginExtension> {

--- a/gradle/build.gradle.kts
+++ b/gradle/build.gradle.kts
@@ -1,6 +1,7 @@
 import io.gitlab.arturbosch.detekt.CONFIGURATION_DETEKT_PLUGINS
 
 val javaVersion = JavaVersion.VERSION_17
+val detektVersion = "1.23.0"
 
 plugins {
     `kotlin-dsl` apply false
@@ -8,7 +9,7 @@ plugins {
     id("com.github.ben-manes.versions") version "0.42.0"
     id("org.cyclonedx.bom") version "1.5.0"
     id("org.jmailen.kotlinter") version "3.10.0" apply false
-    id("io.gitlab.arturbosch.detekt") version "1.20.0" apply false
+    id("io.gitlab.arturbosch.detekt") version "1.23.0" apply false
 }
 
 subprojects {
@@ -40,7 +41,8 @@ subprojects {
     }
 
     dependencies {
-        CONFIGURATION_DETEKT_PLUGINS("io.gitlab.arturbosch.detekt:detekt-formatting:1.20.0")
+        CONFIGURATION_DETEKT_PLUGINS("io.gitlab.arturbosch.detekt:detekt-formatting:$detektVersion")
+        CONFIGURATION_DETEKT_PLUGINS("io.gitlab.arturbosch.detekt:detekt-rules-libraries:$detektVersion")
     }
 
     configure<JavaPluginExtension> {
@@ -133,6 +135,6 @@ tasks {
 
     wrapper {
         distributionType = Wrapper.DistributionType.ALL
-        gradleVersion = "7.5.1"
+        gradleVersion = "8.1.1"
     }
 }

--- a/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/kotlin/build.gradle.kts
+++ b/gradle/kotlin/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
 
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion")
     implementation("io.gitlab.arturbosch.detekt:detekt-formatting:$detektVersion")
-    implementation("io.gitlab.arturbosch.detekt:detekt-rules-libraries:$detektVersion")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/gradle/kotlin/build.gradle.kts
+++ b/gradle/kotlin/build.gradle.kts
@@ -1,6 +1,6 @@
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 
-version = "1.3.0-SNAPSHOT"
+version = "1.4.0-SNAPSHOT"
 
 val functionalTestImplementation = configurations
     .create("functionalTestImplementation")

--- a/gradle/kotlin/build.gradle.kts
+++ b/gradle/kotlin/build.gradle.kts
@@ -1,6 +1,6 @@
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 
-version = "1.4.0-SNAPSHOT"
+version = "2.1.0-SNAPSHOT"
 
 val functionalTestImplementation = configurations
     .create("functionalTestImplementation")

--- a/gradle/kotlin/build.gradle.kts
+++ b/gradle/kotlin/build.gradle.kts
@@ -13,13 +13,10 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
 
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-    implementation("org.jmailen.gradle:kotlinter-gradle:3.10.0")
 
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion")
     implementation("io.gitlab.arturbosch.detekt:detekt-formatting:$detektVersion")
     implementation("io.gitlab.arturbosch.detekt:detekt-rules-libraries:$detektVersion")
-
-    implementation("com.pinterest.ktlint:ktlint-core:0.49.1")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/gradle/kotlin/build.gradle.kts
+++ b/gradle/kotlin/build.gradle.kts
@@ -6,10 +6,10 @@ val functionalTestImplementation = configurations
     .create("functionalTestImplementation")
     .extendsFrom(configurations.getByName("testImplementation"))
 
-val detektVersion = "1.20.0"
+val detektVersion = "1.23.0"
 
 dependencies {
-    val kotlinVersion = "1.7.20"
+    val kotlinVersion = "1.8.21"
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
 
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
@@ -17,8 +17,9 @@ dependencies {
 
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion")
     implementation("io.gitlab.arturbosch.detekt:detekt-formatting:$detektVersion")
+    implementation("io.gitlab.arturbosch.detekt:detekt-rules-libraries:$detektVersion")
 
-    implementation("com.pinterest.ktlint:ktlint-core:0.45.2")
+    implementation("com.pinterest.ktlint:ktlint-core:0.49.1")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/gradle/kotlin/src/functionalTest/kotlin/com/equisoft/standards/kotlin/KotlinStandardsPluginFunctionalTest.kt
+++ b/gradle/kotlin/src/functionalTest/kotlin/com/equisoft/standards/kotlin/KotlinStandardsPluginFunctionalTest.kt
@@ -42,7 +42,7 @@ class KotlinStandardsPluginFunctionalTest {
         projectDir.resolve("build.gradle.kts").writeText(
             """
                 plugins {
-                    kotlin("jvm") version "1.7.20"
+                    kotlin("jvm") version "1.8.21"
                     id("com.equisoft.standards.kotlin")
                 }
                 dependencies {

--- a/gradle/kotlin/src/functionalTest/kotlin/com/equisoft/standards/kotlin/KotlinStandardsPluginFunctionalTest.kt
+++ b/gradle/kotlin/src/functionalTest/kotlin/com/equisoft/standards/kotlin/KotlinStandardsPluginFunctionalTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@SuppressWarnings("FunctionNaming")
+@SuppressWarnings("FunctionNaming", "LargeClass")
 class KotlinStandardsPluginFunctionalTest {
     private lateinit var projectDir: File
     private lateinit var sourcesDir: File
@@ -62,60 +62,7 @@ class KotlinStandardsPluginFunctionalTest {
     }
 
     @Nested
-    inner class Kotlinter {
-        @BeforeTest
-        fun setUp() {
-            runner = runner.appendArguments("-xdetektMain", "-xdetektTest")
-        }
-
-        @Test
-        fun `check should run kotlinter`() {
-            val result = runner.build("check")
-
-            assertKotlinterSuccess(result)
-        }
-
-        @Test
-        fun `checkStatic should run kotlinter`() {
-            val result = runner.build("checkStatic")
-
-            assertKotlinterSuccess(result)
-        }
-
-        @Test
-        fun `kotlinter should ignore import-ordering`() {
-            writeSource(
-                "IgnoreImportOrder.kt",
-                """
-                /* ktlint-disable no-unused-imports */
-                import io.micronaut.test.annotation.MicronautTest
-                import org.junit.jupiter.api.Assertions.assertEquals
-                import org.junit.jupiter.api.Test
-                import javax.inject.Inject
-
-                class IgnoreImportOrder
-                """.trimIndent()
-            )
-
-            val result = runner.build("checkStatic")
-
-            assertKotlinterSuccess(result)
-        }
-
-        private fun assertKotlinterSuccess(result: BuildResult) {
-            assertEquals(TaskOutcome.SUCCESS, result.task(":lintKotlinMain")?.outcome, ":lintKotlinMain")
-            assertEquals(TaskOutcome.SUCCESS, result.task(":lintKotlinTest")?.outcome, ":lintKotlinTest")
-            assertEquals(TaskOutcome.SUCCESS, result.task(":lintKotlin")?.outcome, ":lintKotlin")
-        }
-    }
-
-    @Nested
     inner class Detekt {
-        @BeforeTest
-        fun setUp() {
-            runner = runner.appendArguments("-xlintKotlin")
-        }
-
         @Test
         fun `check should run detekt`() {
             val result = runner.build("check")

--- a/gradle/kotlin/src/main/kotlin/com/equisoft/standards/kotlin/KotlinStandardsPlugin.kt
+++ b/gradle/kotlin/src/main/kotlin/com/equisoft/standards/kotlin/KotlinStandardsPlugin.kt
@@ -71,6 +71,7 @@ class KotlinStandardsPlugin : Plugin<Project> {
         val detektVersion = VersionsCatalog.get("detekt")
         dependencies {
             CONFIGURATION_DETEKT_PLUGINS("io.gitlab.arturbosch.detekt:detekt-formatting:$detektVersion")
+            CONFIGURATION_DETEKT_PLUGINS("io.gitlab.arturbosch.detekt:detekt-rules-libraries:$detektVersion")
         }
     }
 

--- a/gradle/kotlin/src/main/kotlin/com/equisoft/standards/kotlin/KotlinStandardsPlugin.kt
+++ b/gradle/kotlin/src/main/kotlin/com/equisoft/standards/kotlin/KotlinStandardsPlugin.kt
@@ -57,7 +57,6 @@ class KotlinStandardsPlugin : Plugin<Project> {
         val detektVersion = VersionsCatalog.get("detekt")
         dependencies {
             CONFIGURATION_DETEKT_PLUGINS("io.gitlab.arturbosch.detekt:detekt-formatting:$detektVersion")
-            CONFIGURATION_DETEKT_PLUGINS("io.gitlab.arturbosch.detekt:detekt-rules-libraries:$detektVersion")
         }
     }
 

--- a/gradle/kotlin/src/main/kotlin/com/equisoft/standards/kotlin/KotlinStandardsPlugin.kt
+++ b/gradle/kotlin/src/main/kotlin/com/equisoft/standards/kotlin/KotlinStandardsPlugin.kt
@@ -9,23 +9,18 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.resources.TextResource
 import org.gradle.kotlin.dsl.dependencies
-import org.jmailen.gradle.kotlinter.KotlinterExtension
-import org.jmailen.gradle.kotlinter.KotlinterPlugin
 import java.io.InputStream
 
 class KotlinStandardsPlugin : Plugin<Project> {
     private val staticChecks = listOf(
-        "lintKotlin",
         "detektMain",
         "detektTest",
     )
 
     override fun apply(project: Project): Unit = with(project) {
-        plugins.apply(KotlinterPlugin::class.java)
         plugins.apply(DetektPlugin::class.java)
 
         configureDetekt()
-        configureKotlinter()
 
         tasks.register("checkStatic") {
             staticChecks.forEach(::dependsOn)
@@ -33,15 +28,6 @@ class KotlinStandardsPlugin : Plugin<Project> {
 
         tasks.named("check") {
             dependsOn("checkStatic")
-        }
-    }
-
-    private fun Project.configureKotlinter() {
-        extensions.configure(KotlinterExtension::class.java) {
-            reporters = arrayOf("checkstyle", "plain", "sarif")
-            disabledRules = arrayOf(
-                "import-ordering"
-            )
         }
     }
 

--- a/gradle/kotlin/src/main/resources/detekt.yml
+++ b/gradle/kotlin/src/main/resources/detekt.yml
@@ -157,12 +157,3 @@ style:
   VarCouldBeVal:
     active: true
     ignoreAnnotated: ["**.CommandLine.*", "**.Inject", "org.mockito.*"]
-
-libraries:
-  active: true
-  ForbiddenPublicDataClass:
-    active: true
-  LibraryCodeMustSpecifyReturnType:
-    active: false
-  LibraryEntitiesShouldNotBePublic:
-    active: false

--- a/gradle/kotlin/src/main/resources/detekt.yml
+++ b/gradle/kotlin/src/main/resources/detekt.yml
@@ -60,11 +60,15 @@ exceptions:
 
 formatting:
   active: true
+  ClassName:
+    active: true
   ImportOrdering:
     active: true
     layout: '*,java.**,javax.**,kotlin.**,^'
   MaximumLineLength:
-    active: false
+    active: true
+    maxLineLength: 120
+    ignoreBackTickedIdentifier: true
   MultiLineIfElse:
     active: true
   NoEmptyFirstLineInMethodBlock:
@@ -77,6 +81,10 @@ formatting:
     active: true
   SpacingBetweenDeclarationsWithComments:
     active: true
+  TrailingCommaOnCallSite:
+    active: false
+  TrailingCommaOnDeclarationSite:
+    active: false
 
 naming:
   active: true

--- a/gradle/kotlin/src/main/resources/detekt.yml
+++ b/gradle/kotlin/src/main/resources/detekt.yml
@@ -10,7 +10,7 @@ comments:
 
 complexity:
   active: true
-  ComplexMethod:
+  CyclomaticComplexMethod:
     active: true
     threshold: 10
     ignoreSingleWhenExpression: true
@@ -106,12 +106,6 @@ style:
   active: true
   ClassOrdering:
     active: true
-  ForbiddenPublicDataClass:
-    active: true
-  LibraryCodeMustSpecifyReturnType:
-    active: false
-  LibraryEntitiesShouldNotBePublic:
-    active: false
   MagicNumber:
     active: true
     ignoreEnums: true
@@ -155,3 +149,12 @@ style:
   VarCouldBeVal:
     active: true
     ignoreAnnotated: ["**.CommandLine.*", "**.Inject", "org.mockito.*"]
+
+libraries:
+  active: true
+  ForbiddenPublicDataClass:
+    active: true
+  LibraryCodeMustSpecifyReturnType:
+    active: false
+  LibraryEntitiesShouldNotBePublic:
+    active: false

--- a/gradle/kotlin/src/test/kotlin/com/equisoft/standards/kotlin/KotlinStandardsPluginTest.kt
+++ b/gradle/kotlin/src/test/kotlin/com/equisoft/standards/kotlin/KotlinStandardsPluginTest.kt
@@ -20,9 +20,4 @@ class KotlinStandardsPluginTest {
     fun `detekt plugin should be registered`() {
         assertTrue(project.plugins.hasPlugin("io.gitlab.arturbosch.detekt"))
     }
-
-    @Test
-    fun `kotlinter plugin should be registered`() {
-        assertTrue(project.plugins.hasPlugin("org.jmailen.kotlinter"))
-    }
 }

--- a/gradle/micronaut/src/main/kotlin/com/equisoft/standards/gradle/micronaut/MicronautPlugin.kt
+++ b/gradle/micronaut/src/main/kotlin/com/equisoft/standards/gradle/micronaut/MicronautPlugin.kt
@@ -60,7 +60,9 @@ class MicronautPlugin : Plugin<Project> {
                 )
                 runCommand("useradd app && chown app -R /home/app")
                 user("app")
-                instruction("""HEALTHCHECK --interval=10s --timeout=3s --start-period=10s CMD curl --fail http://127.0.0.1:8081/health | grep '"status":"UP"' """) // ktlint-disable max-line-length
+
+                @Suppress("ArgumentListWrapping", "MaxLineLength")
+                instruction("""HEALTHCHECK --interval=10s --timeout=3s --start-period=10s CMD curl --fail http://127.0.0.1:8081/health | grep '"status":"UP"' """)
                 exposedPorts.set(micronautSettingsExtension.exposedPorts)
                 configureDockerfile(this)
             }


### PR DESCRIPTION
kotlin 1.8.21
detekt [1.23.0](https://github.com/detekt/detekt/releases/tag/v1.23.0)

Testé dans equisoftConnect (socket) et cpanel2

BREAKING CHANGES

La tâche `lintKotlin` n'existe plus. Les vérifications de style sont toutes faites par detekt