### PR TITLE
fix(gradle/micronaut): revert gradle-plugin update to fix build

### DIFF
--- a/gradle/micronaut/build.gradle.kts
+++ b/gradle/micronaut/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     implementation("io.micronaut.gradle:micronaut-graalvm-plugin:$micronautPluginVersion")
     implementation("io.micronaut.gradle:micronaut-gradle-plugin:$micronautPluginVersion")
     implementation("io.micronaut.gradle:micronaut-minimal-plugin:$micronautPluginVersion")
-    implementation("com.bmuschko:gradle-docker-plugin:9.3.1")
+    implementation("com.bmuschko:gradle-docker-plugin:8.1.0")
     implementation("org.graalvm.buildtools:native-gradle-plugin:0.9.23")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")


### PR DESCRIPTION
J'avais oublié de tester le build natif. C'est un peu gossant, mais il y a un petit problème qui est corrigé seulement dans la track v4 du plugin micronaut, qui est pas released encore. La v9 de gradle-docker-plugin marche pas avec la v3 du plugin micronaut. https://github.com/micronaut-projects/micronaut-gradle-plugin/pull/590