### PR TITLE
fix(javascript/stylelint): Update rules for postcss-styled-syntax (QCTECH-88)

### DIFF
--- a/javascript/packages/stylelint-config/index.js
+++ b/javascript/packages/stylelint-config/index.js
@@ -49,13 +49,20 @@ module.exports = {
             ],
             customSyntax: 'postcss-styled-syntax',
             rules: {
+                // https://github.com/hudochenkov/postcss-styled-syntax/issues/2
                 'stylistic/indentation': null,
+                'stylistic/no-eol-whitespace': [
+                    true,
+                    {
+                        ignore: ['empty-lines'],
+                    },
+                ],
                 'stylistic/max-line-length': null,
 
                 // stylelint-config-styled-components
-                'no-empty-first-line': null,
+                'stylistic/no-empty-first-line': null,
                 'no-empty-source': null,
-                'no-missing-end-of-source-newline': null,
+                'stylistic/no-missing-end-of-source-newline': null,
                 'property-no-vendor-prefix': true,
                 'value-no-vendor-prefix': true,
             },


### PR DESCRIPTION
Les règles `no-empty-first-line` et `no-missing-end-of-source-newline` sont fournies par `stylelint-stylistic` donc l'override doit être préfixé.

La règle `no-eol-whitespace` émettait beaucoup d'erreurs lorsque le code contenait une déclaration CSS avec une indentation initiale > 0.
```js
function fontSize() {
    return css`
        font-size: 1.5rem;
    `; // <-- Erreur "Unexpected whitespace at end of line" sur cette ligne
}
```

Cependant, comme l'erreur est rapportée sur la dernière ligne du bloc, il est possible de la garder active et d'ignorer simplement les 'empty-lines'. Cette erreur est possiblement liée au même problème qui nous force à désactiver l'indentation.