### PR TITLE
fix(editorconfig): markdown files should use the default max_line_length

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -393,7 +393,6 @@ indent_style = tab
 
 ; Markdown
 [*.md]
-max_line_length = off
 trim_trailing_whitespace = false
 
 ; PHP


### PR DESCRIPTION
Source files are easier to read and edit, and a single `\n` does not impact markdown rendering.