### PR TITLE
fix(eslint-config-typescript): use appropriate no-empty-function rule

### DIFF
--- a/javascript/packages/eslint-config-typescript/index.js
+++ b/javascript/packages/eslint-config-typescript/index.js
@@ -29,6 +29,9 @@ module.exports = {
         'no-useless-constructor': 'off',
         '@typescript-eslint/no-useless-constructor': 'error',
 
+        'no-empty-function': 'off',
+        '@typescript-eslint/no-empty-function': 'error',
+        
         'no-unused-expressions': 'off',
         '@typescript-eslint/no-unused-expressions': 'error',
 


### PR DESCRIPTION
ESLint doesn't deal with empty constructors that do only field initialization (ie DI). The typescript-eslint's version fixes that.