### PR TITLE
feat(editorconfig): ij_php_spaces_around_pipe_in_union_type

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -506,6 +506,7 @@ ij_php_uses_weight = 28
 ij_php_var_weight = 28
 ij_php_variable_naming_style = mixed
 ij_php_version_weight = 28
+ij_php_spaces_around_pipe_in_union_type = true
 
 ; Python
 [*.py]


### PR DESCRIPTION
Depuis très longtemps ça me tanne que le reformat de phpstorm corresponde pas à la règle de phpcs pour les catch avec plusieurs classes.

J'ai trouvé la propriété qui force un espace autour du  `|`

 Par contre, ça a le side-effect d'ajouter l'expace pour tous les types union.  Personnellement j'en met toujours un, mais je rencontre souvent du code qui en a pas.  Phpcs check pas ça.

Avant
```
try {
} catch (TypeA|TypeB $exception) {
}

# Les deux accepté
private TypeA|TypeB $property;
private TypeA | TypeB $property;
```

Maintenant
```
try {
} catch (TypeA | TypeB $exception) {
}

# Les deux accepté
private TypeA | TypeB $property;
```