### PR TITLE
fix(editorconfig): Preserve space inside react empty tag

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -344,6 +344,7 @@ ij_javascript_use_path_mapping = always
 ij_javascript_use_public_modifier = false
 ij_javascript_use_semicolon_after_statement = true
 ij_javascript_var_declaration_wrap = split_into_lines
+ij_html_space_inside_empty_tag = true
 
 ; JSON
 [{*.json,*.json5,.babelrc,.eslintrc,.stylelintrc}]
@@ -603,6 +604,7 @@ ij_typescript_use_path_mapping = always
 ij_typescript_use_public_modifier = false
 ij_typescript_use_semicolon_after_statement = true
 ij_typescript_var_declaration_wrap = split_into_lines
+ij_html_space_inside_empty_tag = true
 
 ; XML
 [{*.plist,*.pom,*.xml,*.xsd,*.xsl,*.xslt}]


### PR DESCRIPTION
Par défaut mon intellij enlève l'espace et ça fait des erreur eslint