### PR TITLE
fix(.editorconfig): update JS and TS array config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -288,6 +288,7 @@ ij_java_use_single_class_imports = true
 
 ; Javascript
 [{*.js,*.jsx,*.mjs}]
+ij_any_array_initializer_right_brace_on_new_line = false
 ij_javascript_align_imports = false
 ij_javascript_align_object_properties = 0
 ij_javascript_align_union_types = false
@@ -548,6 +549,7 @@ ij_shell_switch_cases_indented = false
 
 ; Typescript
 [{*.ts,*.tsx}]
+ij_any_array_initializer_right_brace_on_new_line = false
 ij_typescript_align_imports = false
 ij_typescript_align_object_properties = 0
 ij_typescript_align_union_types = false


### PR DESCRIPTION
Pour éviter que l'autoformat fasse ça 
```
return [{
    label: 'a-label',
    value: 'a-value',
},
];
```

et permette de garder
```
return [{
    label: 'a-label',
    value: 'a-value',
}];
```